### PR TITLE
Making the tool more "idiomatic"

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-Zunstable-options"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+
+[package.metadata.rust-analyzer]
+# This crate uses #![feature(rustc_private)]
+rustc_private = true

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2021-06-01"
+components = ["llvm-tools-preview", "rustc-dev", "rust-src"]

--- a/src/infallible_allocation.rs
+++ b/src/infallible_allocation.rs
@@ -1,25 +1,18 @@
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_hir as hir;
-use rustc_lint::{LateContext, LateLintPass, Level, Lint, LintContext, LintPass};
+use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_middle::mir::mono::MonoItem;
 use rustc_middle::ty::Instance;
 use rustc_mir::monomorphize::collector::MonoItemCollectionMode;
-use rustc_session::declare_lint_pass;
+use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::source_map::Spanned;
 use rustc_span::symbol::sym;
 
-pub static INFALLIBLE_ALLOCATION: Lint = Lint {
-    name: "klint::infallible_allocation",
-    default_level: Level::Warn,
-    desc: "",
-    edition_lint_opts: None,
-    report_in_external_macro: true,
-    future_incompatible: None,
-    is_plugin: true,
-    feature_gate: None,
-    crate_level_only: false,
-};
-
+declare_tool_lint! {
+    pub klint::INFALLIBLE_ALLOCATION,
+    Warn,
+    ""
+}
 
 declare_lint_pass!(InfallibleAllocation => [INFALLIBLE_ALLOCATION]);
 

--- a/src/infallible_allocation.rs
+++ b/src/infallible_allocation.rs
@@ -4,6 +4,7 @@ use rustc_lint::{LateContext, LateLintPass, Level, Lint, LintContext, LintPass};
 use rustc_middle::mir::mono::MonoItem;
 use rustc_middle::ty::Instance;
 use rustc_mir::monomorphize::collector::MonoItemCollectionMode;
+use rustc_session::declare_lint_pass;
 use rustc_span::source_map::Spanned;
 use rustc_span::symbol::sym;
 
@@ -19,13 +20,8 @@ pub static INFALLIBLE_ALLOCATION: Lint = Lint {
     crate_level_only: false,
 };
 
-pub struct InfallibleAllocation;
 
-impl LintPass for InfallibleAllocation {
-    fn name(&self) -> &'static str {
-        INFALLIBLE_ALLOCATION.name
-    }
-}
+declare_lint_pass!(InfallibleAllocation => [INFALLIBLE_ALLOCATION]);
 
 impl<'tcx> LateLintPass<'tcx> for InfallibleAllocation {
     fn check_crate(&mut self, cx: &LateContext<'tcx>, _: &'tcx hir::Crate<'tcx>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 #![feature(rustc_private)]
+#![warn(rustc::internal)]
 
 extern crate rustc_data_structures;
 extern crate rustc_driver;


### PR DESCRIPTION
There are some convenience things for writing lints in rustc. This adds those things:

- Use rustc internal lints, to not get into trouble using the rustc internals
- Use macros for declaring the lint
- Make the lint a tool lint. This allows for crates using this linter to control the lint level, with the `register_tool` feature
    ```rust
    #![feature(register_tool)]
    #![register_tool(klint)]
    #![allow(klint::infallible_allocation)]

    fn main() {
        let _s: String = "str".into();
    }
    ```
- Add a `rust-toolchain` file, so people cloning and compiling this tool won't have to search for a nightly that compiles this. The `rust-toolchain ` file won't be used when installing it with `cargo install --git ....` though.
- And to make it easier to hack more lints in this tool, make it possible for rust-analyzer to understand rustc internals 