### PR TITLE
Fix build for Rust 1.88.0

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -3,5 +3,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
 [toolchain]
-channel = "1.87"
+channel = "1.88.0"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src"]

--- a/src/atomic_context.rs
+++ b/src/atomic_context.rs
@@ -400,7 +400,7 @@ impl<'tcx> LateLintPass<'tcx> for AtomicContext<'tcx> {
         let identity = cx
             .tcx
             .erase_regions(GenericArgs::identity_for_item(self.cx.tcx, def_id));
-        let instance = Instance::new(def_id.into(), identity);
+        let instance = Instance::new_raw(def_id.into(), identity);
         let poly_instance = TypingEnv::post_analysis(*self.cx, def_id).as_query_input(instance);
         let _ = self.cx.instance_adjustment(poly_instance);
         let _ = self.cx.instance_expectation(poly_instance);

--- a/src/mir.rs
+++ b/src/mir.rs
@@ -217,7 +217,9 @@ impl<'tcx> AnalysisCtxt<'tcx> {
             | ty::InstanceKind::CloneShim(..)
             | ty::InstanceKind::ThreadLocalShim(..)
             | ty::InstanceKind::FnPtrAddrShim(..)
-            | ty::InstanceKind::AsyncDropGlueCtorShim(..) => self.mir_shims(instance),
+            | ty::InstanceKind::AsyncDropGlueCtorShim(..)
+            | ty::InstanceKind::FutureDropPollShim(..)
+            | ty::InstanceKind::AsyncDropGlue(..) => self.mir_shims(instance),
         }
     }
 }

--- a/src/mir/elaborate_drop.rs
+++ b/src/mir/elaborate_drop.rs
@@ -233,6 +233,10 @@ where
                         target: self.succ,
                         unwind: self.unwind.into_action(),
                         replace: false,
+                        // TODO
+                        drop: None,
+                        // TODO
+                        async_fut: None,
                     },
                 );
             }
@@ -775,6 +779,10 @@ where
                 target: loop_block,
                 unwind: unwind.into_action(),
                 replace: false,
+                // TODO
+                drop: None,
+                // TODO
+                async_fut: None,
             },
         );
 
@@ -1025,6 +1033,10 @@ where
             target,
             unwind: unwind.into_action(),
             replace: false,
+            // TODO
+            drop: None,
+            // TODO
+            async_fut: None,
         };
         self.new_block(unwind, block)
     }

--- a/src/monomorphize_collector.rs
+++ b/src/monomorphize_collector.rs
@@ -128,7 +128,7 @@ pub fn collect_crate_mono_items(
             let mut recursion_depths = DefIdMap::default();
             let should_gen = match root {
                 MonoItem::Static(def_id) => {
-                    let instance = Instance::mono(tcx, def_id);
+                    let instance = Instance::mono(tcx, *def_id);
                     should_codegen_locally(tcx, &instance)
                 }
                 MonoItem::Fn(instance) => should_codegen_locally(tcx, &instance),
@@ -137,7 +137,7 @@ pub fn collect_crate_mono_items(
             if should_gen {
                 collect_items_rec(
                     tcx,
-                    dummy_spanned(root),
+                    dummy_spanned(*root),
                     &visited,
                     &mut recursion_depths,
                     recursion_limit,
@@ -379,7 +379,7 @@ fn shrunk_instance_name<'tcx>(
 
         let path = tcx
             .output_filenames(())
-            .temp_path_ext("long-type.txt", None);
+            .temp_path_ext_for_cgu("txt", "long-type", None);
         let written_to_path = std::fs::write(&path, s).ok().map(|_| path);
 
         (shrunk, written_to_path)
@@ -740,14 +740,14 @@ fn visit_instance_use<'tcx>(
         ty::InstanceKind::ThreadLocalShim(..) => {
             bug!("{:?} being reified", instance);
         }
-        ty::InstanceKind::DropGlue(_, None) | ty::InstanceKind::AsyncDropGlueCtorShim(_, None) => {
+        ty::InstanceKind::DropGlue(_, None) => {
             // Don't need to emit noop drop glue if we are calling directly.
             if !is_direct_call {
                 output.push(create_fn_mono_item(tcx, instance, source));
             }
         }
         ty::InstanceKind::DropGlue(_, Some(_))
-        | ty::InstanceKind::AsyncDropGlueCtorShim(_, Some(_))
+        | ty::InstanceKind::AsyncDropGlueCtorShim(_, _)
         | ty::InstanceKind::VTableShim(..)
         | ty::InstanceKind::ReifyShim(..)
         | ty::InstanceKind::ClosureOnceShim { .. }
@@ -755,7 +755,9 @@ fn visit_instance_use<'tcx>(
         | ty::InstanceKind::Item(..)
         | ty::InstanceKind::FnPtrShim(..)
         | ty::InstanceKind::CloneShim(..)
-        | ty::InstanceKind::FnPtrAddrShim(..) => {
+        | ty::InstanceKind::FnPtrAddrShim(..)
+        | ty::InstanceKind::FutureDropPollShim(..)
+        | ty::InstanceKind::AsyncDropGlue(..) => {
             output.push(create_fn_mono_item(tcx, instance, source));
         }
     }
@@ -980,7 +982,7 @@ impl<'v> RootCollector<'_, 'v> {
                     debug!("RootCollector: ADT drop-glue for {id:?}",);
 
                     let item = self.tcx.hir_item(id);
-                    let ty = Instance::new(item.owner_id.to_def_id(), GenericArgs::empty())
+                    let ty = Instance::new_raw(item.owner_id.to_def_id(), GenericArgs::empty())
                         .ty(self.tcx, ty::TypingEnv::fully_monomorphized());
                     visit_drop_use(self.tcx, ty, true, DUMMY_SP, self.output);
                 }

--- a/src/preempt_count/adjustment.rs
+++ b/src/preempt_count/adjustment.rs
@@ -32,7 +32,7 @@ impl<'tcx> AnalysisCtxt<'tcx> {
     fn poly_instance_of_def_id(&self, def_id: DefId) -> PseudoCanonicalInput<'tcx, Instance<'tcx>> {
         let poly_typing_env = TypingEnv::post_analysis(self.tcx, def_id);
         let poly_args = self.erase_regions(GenericArgs::identity_for_item(self.tcx, def_id));
-        poly_typing_env.as_query_input(Instance::new(def_id, poly_args))
+        poly_typing_env.as_query_input(Instance::new_raw(def_id, poly_args))
     }
 
     pub fn emit_with_use_site_info<G: EmissionGuarantee>(
@@ -298,11 +298,9 @@ impl<'tcx> AnalysisCtxt<'tcx> {
 
         let mut adjustment = AdjustmentBoundsOrError::default();
         for (b, data) in rustc_middle::mir::traversal::reachable(body) {
-            match data.terminator().kind {
-                TerminatorKind::Return => {
-                    adjustment.join(&analysis_result.results().entry_set_for_block(b));
-                }
-                _ => (),
+            if data.terminator().kind == TerminatorKind::Return {
+                analysis_result.seek_to_block_start(b);
+                adjustment.join(analysis_result.get());
             }
         }
         let adjustment = adjustment.into_result()?;
@@ -671,7 +669,7 @@ memoize!(
             let poly_args =
                 cx.erase_regions(GenericArgs::identity_for_item(cx.tcx, instance.def_id()));
             let poly_poly_instance =
-                poly_typing_env.as_query_input(Instance::new(instance.def_id(), poly_args));
+                poly_typing_env.as_query_input(Instance::new_raw(instance.def_id(), poly_args));
             generic = poly_poly_instance == poly_instance;
             if !generic {
                 match cx.instance_adjustment(poly_poly_instance) {
@@ -830,7 +828,7 @@ memoize!(
             let poly_args =
                 cx.erase_regions(GenericArgs::identity_for_item(cx.tcx, instance.def_id()));
             let poly_poly_instance =
-                poly_typing_env.as_query_input(Instance::new(instance.def_id(), poly_args));
+                poly_typing_env.as_query_input(Instance::new_raw(instance.def_id(), poly_args));
             let generic = poly_poly_instance == poly_instance;
             if !generic {
                 match cx.instance_adjustment_check(poly_poly_instance) {

--- a/src/preempt_count/annotation.rs
+++ b/src/preempt_count/annotation.rs
@@ -40,11 +40,11 @@ impl<'tcx> AnalysisCtxt<'tcx> {
             if let Some(adt_def) = self_ty.skip_binder().ty_adt_def()
                 && let data = self.def_path(adt_def.did()).data
                 && data.len() == 3
-                && let DefPathData::TypeNs(Some(task)) = data[0].data
+                && let DefPathData::TypeNs(task) = data[0].data
                 && task == *crate::symbol::task
-                && let DefPathData::TypeNs(Some(wake)) = data[1].data
+                && let DefPathData::TypeNs(wake) = data[1].data
                 && wake == *crate::symbol::wake
-                && let DefPathData::TypeNs(Some(waker)) = data[2].data
+                && let DefPathData::TypeNs(waker) = data[2].data
                 && waker == *crate::symbol::Waker
             {
                 if fn_name == sym::clone
@@ -65,9 +65,9 @@ impl<'tcx> AnalysisCtxt<'tcx> {
         let data = self.def_path(def_id).data;
 
         if data.len() == 3
-            && let DefPathData::TypeNs(Some(any)) = data[0].data
+            && let DefPathData::TypeNs(any) = data[0].data
             && any == sym::any
-            && let DefPathData::TypeNs(Some(any_trait)) = data[1].data
+            && let DefPathData::TypeNs(any_trait) = data[1].data
             && any_trait == sym::Any
             && let DefPathData::ValueNs(_any_fn) = data[2].data
         {
@@ -80,9 +80,9 @@ impl<'tcx> AnalysisCtxt<'tcx> {
         }
 
         if data.len() == 3
-            && let DefPathData::TypeNs(Some(error)) = data[0].data
+            && let DefPathData::TypeNs(error) = data[0].data
             && error == *crate::symbol::error
-            && let DefPathData::TypeNs(Some(error_trait)) = data[1].data
+            && let DefPathData::TypeNs(error_trait) = data[1].data
             && error_trait == sym::Error
             && let DefPathData::ValueNs(_any_fn) = data[2].data
         {
@@ -95,7 +95,7 @@ impl<'tcx> AnalysisCtxt<'tcx> {
         }
 
         if data.len() == 3
-            && let DefPathData::TypeNs(Some(fmt)) = data[0].data
+            && let DefPathData::TypeNs(fmt) = data[0].data
             && fmt == sym::fmt
             && let DefPathData::TypeNs(_fmt_trait) = data[1].data
             && let DefPathData::ValueNs(fmt_fn) = data[2].data
@@ -109,9 +109,9 @@ impl<'tcx> AnalysisCtxt<'tcx> {
             };
         }
         if data.len() == 3
-            && let DefPathData::TypeNs(Some(fmt)) = data[0].data
+            && let DefPathData::TypeNs(fmt) = data[0].data
             && fmt == sym::fmt
-            && let DefPathData::TypeNs(Some(write)) = data[1].data
+            && let DefPathData::TypeNs(write) = data[1].data
             && write == *crate::symbol::Write
             && let DefPathData::ValueNs(_write_fn) = data[2].data
         {
@@ -123,7 +123,7 @@ impl<'tcx> AnalysisCtxt<'tcx> {
             };
         }
         if data.len() == 2
-            && let DefPathData::TypeNs(Some(fmt)) = data[0].data
+            && let DefPathData::TypeNs(fmt) = data[0].data
             && fmt == sym::fmt
             && let DefPathData::ValueNs(write) = data[1].data
             && write == *crate::symbol::write

--- a/src/preempt_count/check.rs
+++ b/src/preempt_count/check.rs
@@ -794,7 +794,7 @@ memoize!(
             let poly_args =
                 cx.erase_regions(GenericArgs::identity_for_item(cx.tcx, instance.def_id()));
             let poly_poly_instance =
-                poly_typing_env.as_query_input(Instance::new(instance.def_id(), poly_args));
+                poly_typing_env.as_query_input(Instance::new_raw(instance.def_id(), poly_args));
             let generic = poly_poly_instance == poly_instance;
             if !generic {
                 match cx.instance_check(poly_poly_instance) {

--- a/src/preempt_count/expectation.rs
+++ b/src/preempt_count/expectation.rs
@@ -1014,7 +1014,7 @@ memoize!(
             let poly_args =
                 cx.erase_regions(GenericArgs::identity_for_item(cx.tcx, instance.def_id()));
             let poly_poly_instance =
-                poly_typing_env.as_query_input(Instance::new(instance.def_id(), poly_args));
+                poly_typing_env.as_query_input(Instance::new_raw(instance.def_id(), poly_args));
             generic = poly_poly_instance == poly_instance;
             if !generic {
                 match cx.instance_expectation(poly_poly_instance) {
@@ -1174,7 +1174,7 @@ memoize!(
             let poly_args =
                 cx.erase_regions(GenericArgs::identity_for_item(cx.tcx, instance.def_id()));
             let poly_poly_instance =
-                poly_typing_env.as_query_input(Instance::new(instance.def_id(), poly_args));
+                poly_typing_env.as_query_input(Instance::new_raw(instance.def_id(), poly_args));
             let generic = poly_poly_instance == poly_instance;
             if !generic {
                 match cx.instance_expectation_check(poly_poly_instance) {

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -23,8 +23,8 @@ fn run_ui_tests(bless: bool) {
         ..Default::default()
     };
 
-    config.target_rustcflags = Some(format!(
-        "-Zcrate-attr=feature(register_tool) -Zcrate-attr=register_tool(klint)"
+    config.target_rustcflags = Some(String::from(
+        "-Zcrate-attr=feature(register_tool) -Zcrate-attr=register_tool(klint)",
     ));
 
     config.src_base = "tests/ui".into();
@@ -37,6 +37,6 @@ fn run_ui_tests(bless: bool) {
 
 #[test]
 fn compile_test() {
-    let bless = env::var("BLESS").map_or(false, |x| !x.trim().is_empty());
+    let bless = env::var("BLESS").is_ok_and(|x| !x.trim().is_empty());
     run_ui_tests(bless);
 }


### PR DESCRIPTION
This PR allows `klint` to build with Rust `1.88.0` and also pass the included tests.
