### PR TITLE
Add `assert_hierarchy` lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,4 @@ If you want to check it out, you can opt into it with `-Dklint::atomic_context`.
 * [`build_error` checks](doc/build_error.md)
 * [Stack frame size check](doc/stack_size.md)
 * [Prelude check](doc/not_using_prelude.md)
+* [Assertion hierarchy](doc/assert_hierarchy.md)

--- a/doc/assert_hierarchy.md
+++ b/doc/assert_hierarchy.md
@@ -1,0 +1,101 @@
+<!--
+SPDX-License-Identifier: MIT OR Apache-2.0
+-->
+
+# `assert_hierarchy`
+
+This lint warns when an assertion can use a stronger compile-time assertion form.
+
+The preference order is:
+
+1. `static_assert!`
+2. `const_assert!`
+3. `build_assert!`
+
+`static_assert!` is preferred when the condition is fully closed over compile-time context.
+`const_assert!` is preferred when the condition is valid in a generic-aware const context but still
+depends on generics or expression-local bindings. `build_assert!` is only needed once the condition
+depends on variables or other non-const context.
+
+## `build_assert!` To `static_assert!`
+
+These trigger the lint with a `static_assert!` suggestion:
+
+```rust
+fn literal_const_only() {
+    build_assert!(1 < LIMIT);
+}
+```
+
+```rust
+fn wrapper_const_only() {
+    forward_build_assert!(OFFSET < LIMIT);
+}
+```
+
+Macro-generated assertions can also trigger:
+
+```rust
+macro_rules! forward_const_check {
+    ($expr:expr $(,)?) => {
+        build_assert!($expr);
+        let _x = 0usize;
+    };
+}
+
+fn f<const N: usize>() {
+    forward_const_check!(N > 0);
+}
+```
+
+## `build_assert!` To `const_assert!`
+
+These trigger the lint with a `const_assert!` suggestion:
+
+```rust
+fn const_generic_only<const N: usize>() {
+    build_assert!(OFFSET < N);
+}
+```
+
+```rust
+const fn helper<const N: usize>() -> usize {
+    N - 1
+}
+
+fn const_fn_helper_only<const N: usize>() {
+    build_assert!(helper::<N>() < N);
+}
+```
+
+## `const_assert!` To `static_assert!`
+
+This also applies to `const_assert!` when it does not actually need generic-aware const context:
+
+```rust
+fn const_assert_static_only() {
+    const_assert!(1 < LIMIT);
+}
+```
+
+## Cases That Do Not Trigger
+
+These do not trigger `assert_hierarchy`:
+
+```rust
+fn const_assert_generic<const N: usize>() {
+    const_assert!(OFFSET < N);
+}
+```
+
+```rust
+fn runtime_direct(offset: usize, n: usize) {
+    build_assert!(offset < n);
+}
+```
+
+```rust
+fn non_const_fn_helper<const N: usize>() {
+    build_assert!(helper::<N>() < N);
+}
+```

--- a/src/assert_hierarchy.rs
+++ b/src/assert_hierarchy.rs
@@ -1,0 +1,490 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use rustc_data_structures::fx::FxHashMap;
+use rustc_hir::def::{DefKind, Res};
+use rustc_hir::def_id::DefId;
+use rustc_hir::intravisit as hir_visit;
+use rustc_hir::{Body, Expr, HirId, QPath, StmtKind, UnOp};
+use rustc_lint::{LateContext, LateLintPass, LintContext};
+use rustc_middle::ty::{TyCtxt, TypeVisitableExt, TypeckResults};
+use rustc_session::{declare_tool_lint, impl_lint_pass};
+use rustc_span::{BytePos, Span, Symbol};
+
+use crate::ctxt::AnalysisCtxt;
+
+declare_tool_lint! {
+    pub klint::ASSERT_HIERARCHY,
+    Warn,
+    "assertion can be written as a stronger compile-time assertion"
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum AssertStrength {
+    Build,
+    Const,
+    Static,
+}
+
+impl AssertStrength {
+    fn combine<I>(strengths: I) -> Self
+    where
+        I: IntoIterator<Item = Self>,
+    {
+        strengths
+            .into_iter()
+            .min()
+            .unwrap_or(AssertStrength::Static)
+    }
+
+    fn local_binding(self) -> Self {
+        match self {
+            AssertStrength::Build => AssertStrength::Build,
+            AssertStrength::Const | AssertStrength::Static => AssertStrength::Const,
+        }
+    }
+
+    fn replacement_macro(self, current: AssertionKind) -> Option<Symbol> {
+        match (current, self) {
+            (AssertionKind::Build, AssertStrength::Static) => Some(crate::symbol::static_assert),
+            (AssertionKind::Build, AssertStrength::Const) => Some(crate::symbol::const_assert),
+            (AssertionKind::Const, AssertStrength::Static) => Some(crate::symbol::static_assert),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum AssertionKind {
+    Build,
+    Const,
+}
+
+impl AssertionKind {
+    fn macro_name(self) -> Symbol {
+        match self {
+            AssertionKind::Build => crate::symbol::build_assert,
+            AssertionKind::Const => crate::symbol::const_assert,
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct AssertionCondition {
+    kind: AssertionKind,
+    call_site: Span,
+    condition_span: Span,
+}
+
+fn assertion_call_site(
+    tcx: TyCtxt<'_>,
+    span: Span,
+    assertions: &[(AssertionKind, Option<DefId>, Symbol)],
+) -> Option<(AssertionKind, Span)> {
+    span.macro_backtrace()
+        .find(|expn_data| {
+            let Some(macro_def_id) = expn_data.macro_def_id else {
+                return false;
+            };
+
+            assertions.iter().any(|&(_, assertion, name)| {
+                Some(macro_def_id) == assertion || tcx.item_name(macro_def_id) == name
+            })
+        })
+        .and_then(|expn_data| {
+            let macro_def_id = expn_data.macro_def_id?;
+            let kind = assertions.iter().find_map(|&(kind, assertion, name)| {
+                (Some(macro_def_id) == assertion || tcx.item_name(macro_def_id) == name)
+                    .then_some(kind)
+            })?;
+            Some((kind, expn_data.call_site.source_callsite()))
+        })
+}
+
+fn assertion_condition(
+    tcx: TyCtxt<'_>,
+    expr: &Expr<'_>,
+    assertions: &[(AssertionKind, Option<DefId>, Symbol)],
+) -> Option<AssertionCondition> {
+    let rustc_hir::ExprKind::Unary(UnOp::Not, condition) = expr.kind else {
+        return None;
+    };
+    if !expr.span.from_expansion() {
+        return None;
+    }
+
+    let (kind, call_site) = assertion_call_site(tcx, expr.span, assertions)?;
+    let condition_span = condition.span.source_callsite();
+    Some(AssertionCondition {
+        kind,
+        call_site,
+        condition_span,
+    })
+}
+
+fn emit_assert_hierarchy(
+    cx: &LateContext<'_>,
+    assertion_span: Span,
+    condition_span: Span,
+    current: AssertionKind,
+    strength: AssertStrength,
+) {
+    let Some(replacement_macro) = strength.replacement_macro(current) else {
+        return;
+    };
+    let primary = match replacement_macro {
+        crate::symbol::static_assert => "this assertion can use the stronger `static_assert!` form",
+        crate::symbol::const_assert => "this assertion can use the stronger `const_assert!` form",
+        _ => return,
+    };
+    let note = match (current, strength) {
+        (AssertionKind::Build, AssertStrength::Static)
+        | (AssertionKind::Const, AssertStrength::Static) => {
+            "this asserted condition is closed over compile-time context, so `static_assert!` is the stronger form here"
+        }
+        (AssertionKind::Build, AssertStrength::Const) => {
+            "this asserted condition is valid in a generic-aware const context, so `build_assert!` is unnecessary here"
+        }
+        _ => return,
+    };
+
+    if let Some(macro_name_span) = macro_name_span(cx, assertion_span, current.macro_name()) {
+        cx.emit_span_lint(
+            ASSERT_HIERARCHY,
+            assertion_span,
+            AssertHierarchySuggestionDiag {
+                assertion_span,
+                condition_span,
+                macro_name_span,
+                primary,
+                replacement_macro,
+                note,
+            },
+        );
+    } else {
+        cx.emit_span_lint(
+            ASSERT_HIERARCHY,
+            assertion_span,
+            AssertHierarchyDiag {
+                assertion_span,
+                condition_span,
+                primary,
+                note,
+            },
+        );
+    }
+}
+
+fn macro_name_span(cx: &LateContext<'_>, call_site: Span, current_macro: Symbol) -> Option<Span> {
+    let source = cx.sess().source_map().span_to_snippet(call_site).ok()?;
+    let name = current_macro.as_str();
+    let rest = source.strip_prefix(name)?;
+    if !rest.starts_with('!') {
+        return None;
+    }
+
+    Some(call_site.with_hi(call_site.lo() + BytePos(name.len() as u32)))
+}
+
+#[derive(Diagnostic)]
+#[diag("{$primary}")]
+struct AssertHierarchyDiag {
+    #[primary_span]
+    pub assertion_span: Span,
+    #[note("{$note}")]
+    pub condition_span: Span,
+    pub primary: &'static str,
+    pub note: &'static str,
+}
+
+#[derive(Diagnostic)]
+#[diag("{$primary}")]
+struct AssertHierarchySuggestionDiag {
+    #[primary_span]
+    pub assertion_span: Span,
+    #[note("{$note}")]
+    pub condition_span: Span,
+    #[suggestion(
+        "replace the macro name",
+        code = "{replacement_macro}",
+        applicability = "machine-applicable"
+    )]
+    pub macro_name_span: Span,
+    pub primary: &'static str,
+    pub replacement_macro: Symbol,
+    pub note: &'static str,
+}
+
+pub struct AssertHierarchy<'tcx> {
+    pub cx: &'tcx AnalysisCtxt<'tcx>,
+}
+
+impl_lint_pass!(AssertHierarchy<'_> => [ASSERT_HIERARCHY]);
+
+struct AssertFnState<'a, 'tcx> {
+    cx: &'a AnalysisCtxt<'tcx>,
+    late_cx: &'a LateContext<'tcx>,
+    typeck: &'tcx TypeckResults<'tcx>,
+    assertions: [(AssertionKind, Option<DefId>, Symbol); 2],
+    env: LocalEnv,
+}
+
+struct LocalEnv {
+    bindings: FxHashMap<HirId, AssertStrength>,
+}
+
+impl LocalEnv {
+    fn new() -> Self {
+        Self {
+            bindings: FxHashMap::default(),
+        }
+    }
+
+    fn bind_pattern(&mut self, pat: &rustc_hir::Pat<'_>, strength: AssertStrength) {
+        pat.each_binding(|_, hir_id, _, _| {
+            self.bindings.insert(hir_id, strength);
+        });
+    }
+
+    fn get_dependency(&self, hir_id: HirId) -> Option<&AssertStrength> {
+        self.bindings.get(&hir_id)
+    }
+}
+
+impl<'a, 'tcx> AssertFnState<'a, 'tcx> {
+    fn path_strength(&self, qpath: &QPath<'tcx>, hir_id: HirId) -> AssertStrength {
+        let resolved_strength = match self.typeck.qpath_res(qpath, hir_id) {
+            Res::Local(local) => self
+                .env
+                .get_dependency(local)
+                .copied()
+                .unwrap_or(AssertStrength::Build),
+            Res::Def(DefKind::Const { .. } | DefKind::AssocConst { .. }, _) => {
+                AssertStrength::Static
+            }
+            Res::Def(DefKind::ConstParam, _) => AssertStrength::Const,
+            _ => AssertStrength::Build,
+        };
+
+        AssertStrength::combine([resolved_strength, self.generic_strength(hir_id)])
+    }
+
+    fn generic_strength(&self, hir_id: HirId) -> AssertStrength {
+        self.typeck
+            .node_args_opt(hir_id)
+            .map(|args| {
+                if args.has_non_region_param() {
+                    AssertStrength::Const
+                } else {
+                    AssertStrength::Static
+                }
+            })
+            .unwrap_or(AssertStrength::Static)
+    }
+
+    fn combine_exprs<I>(&mut self, exprs: I) -> AssertStrength
+    where
+        I: IntoIterator<Item = &'tcx Expr<'tcx>>,
+    {
+        AssertStrength::combine(exprs.into_iter().map(|expr| self.expr_strength(expr)))
+    }
+
+    fn block_strength(&mut self, block: &'tcx rustc_hir::Block<'tcx>) -> AssertStrength {
+        let outer_bindings = std::mem::take(&mut self.env.bindings);
+
+        let strength = (|| {
+            for stmt in block.stmts {
+                match stmt.kind {
+                    StmtKind::Let(local) => {
+                        let Some(init) = local.init else {
+                            return AssertStrength::Build;
+                        };
+                        let strength = self.expr_strength(init).local_binding();
+                        self.env.bind_pattern(local.pat, strength);
+                        if let Some(els) = local.els {
+                            return self.block_strength(els);
+                        }
+                    }
+                    StmtKind::Expr(expr) | StmtKind::Semi(expr) => {
+                        if self.expr_strength(expr) == AssertStrength::Build {
+                            return AssertStrength::Build;
+                        }
+                    }
+                    StmtKind::Item(..) => return AssertStrength::Build,
+                }
+            }
+
+            block
+                .expr
+                .map(|expr| self.expr_strength(expr))
+                .unwrap_or(AssertStrength::Static)
+        })();
+
+        self.env.bindings = outer_bindings;
+        strength
+    }
+
+    fn call_strength(
+        &mut self,
+        callee: &'tcx Expr<'tcx>,
+        args: &'tcx [Expr<'tcx>],
+    ) -> AssertStrength {
+        let rustc_hir::ExprKind::Path(ref qpath) = callee.kind else {
+            return AssertStrength::Build;
+        };
+        let resolved = self.typeck.qpath_res(qpath, callee.hir_id);
+        let arg_strength = AssertStrength::combine([
+            self.combine_exprs(args.iter()),
+            self.generic_strength(callee.hir_id),
+        ]);
+
+        if arg_strength != AssertStrength::Build
+            && matches!(resolved, Res::Def(DefKind::Ctor(..), _))
+        {
+            return arg_strength;
+        }
+
+        if arg_strength != AssertStrength::Build
+            && let Res::Def(DefKind::Fn | DefKind::AssocFn, def_id) = resolved
+            && self.cx.tcx.is_const_fn(def_id)
+        {
+            return arg_strength;
+        }
+
+        AssertStrength::Build
+    }
+
+    fn method_call_strength(
+        &mut self,
+        expr: &'tcx Expr<'tcx>,
+        receiver: &'tcx Expr<'tcx>,
+        args: &'tcx [Expr<'tcx>],
+    ) -> AssertStrength {
+        let arg_strength = AssertStrength::combine([
+            self.combine_exprs(std::iter::once(receiver).chain(args.iter())),
+            self.generic_strength(expr.hir_id),
+        ]);
+
+        if arg_strength != AssertStrength::Build
+            && let Some(def_id) = self.typeck.type_dependent_def_id(expr.hir_id)
+            && self.cx.tcx.is_const_fn(def_id)
+        {
+            return arg_strength;
+        }
+
+        AssertStrength::Build
+    }
+
+    fn expr_strength(&mut self, expr: &'tcx Expr<'tcx>) -> AssertStrength {
+        match expr.kind {
+            rustc_hir::ExprKind::ConstBlock(..) => AssertStrength::Const,
+            rustc_hir::ExprKind::Lit(..) => AssertStrength::Static,
+            rustc_hir::ExprKind::Path(ref qpath) => self.path_strength(qpath, expr.hir_id),
+            rustc_hir::ExprKind::Use(inner, _)
+            | rustc_hir::ExprKind::Unary(_, inner)
+            | rustc_hir::ExprKind::Cast(inner, _)
+            | rustc_hir::ExprKind::Type(inner, _)
+            | rustc_hir::ExprKind::DropTemps(inner)
+            | rustc_hir::ExprKind::Field(inner, _)
+            | rustc_hir::ExprKind::AddrOf(_, _, inner)
+            | rustc_hir::ExprKind::UnsafeBinderCast(_, inner, _) => self.expr_strength(inner),
+            rustc_hir::ExprKind::Binary(_, lhs, rhs)
+            | rustc_hir::ExprKind::AssignOp(_, lhs, rhs)
+            | rustc_hir::ExprKind::Index(lhs, rhs, _) => self.combine_exprs([lhs, rhs]),
+            rustc_hir::ExprKind::Assign(..) | rustc_hir::ExprKind::Repeat(..) => {
+                AssertStrength::Build
+            }
+            rustc_hir::ExprKind::Array(exprs) | rustc_hir::ExprKind::Tup(exprs) => {
+                self.combine_exprs(exprs.iter())
+            }
+            rustc_hir::ExprKind::Block(block, _) => self.block_strength(block),
+            rustc_hir::ExprKind::Struct(_, fields, tail) => {
+                let tail_strength = match tail {
+                    rustc_hir::StructTailExpr::None => AssertStrength::Static,
+                    rustc_hir::StructTailExpr::Base(expr) => self.expr_strength(expr),
+                    rustc_hir::StructTailExpr::DefaultFields(_)
+                    | rustc_hir::StructTailExpr::NoneWithError(_) => AssertStrength::Build,
+                };
+                AssertStrength::combine(
+                    fields
+                        .iter()
+                        .map(|field| self.expr_strength(field.expr))
+                        .chain(std::iter::once(tail_strength)),
+                )
+            }
+            rustc_hir::ExprKind::If(condition, then_expr, else_expr) => AssertStrength::combine(
+                std::iter::once(self.expr_strength(condition))
+                    .chain(std::iter::once(self.expr_strength(then_expr)))
+                    .chain(else_expr.into_iter().map(|expr| self.expr_strength(expr))),
+            ),
+            rustc_hir::ExprKind::Match(scrutinee, arms, _) => {
+                let mut strengths = Vec::with_capacity(1 + arms.len() * 2);
+                strengths.push(self.expr_strength(scrutinee));
+                for arm in arms {
+                    if let Some(guard) = arm.guard {
+                        strengths.push(self.expr_strength(guard));
+                    }
+                    strengths.push(self.expr_strength(arm.body));
+                }
+                AssertStrength::combine(strengths)
+            }
+            rustc_hir::ExprKind::Call(callee, args) => self.call_strength(callee, args),
+            rustc_hir::ExprKind::MethodCall(_, receiver, args, _) => {
+                self.method_call_strength(expr, receiver, args)
+            }
+            _ => AssertStrength::Build,
+        }
+    }
+}
+
+impl<'tcx> hir_visit::Visitor<'tcx> for AssertFnState<'_, 'tcx> {
+    fn visit_expr(&mut self, expr: &'tcx Expr<'tcx>) {
+        if let rustc_hir::ExprKind::Unary(UnOp::Not, condition_expr) = expr.kind
+            && let Some(condition) = assertion_condition(self.cx.tcx, expr, &self.assertions)
+            && let strength @ (AssertStrength::Const | AssertStrength::Static) =
+                self.expr_strength(condition_expr)
+        {
+            emit_assert_hierarchy(
+                self.late_cx,
+                condition.call_site,
+                condition.condition_span,
+                condition.kind,
+                strength,
+            );
+        }
+        hir_visit::walk_expr(self, expr);
+    }
+}
+
+impl<'tcx> LateLintPass<'tcx> for AssertHierarchy<'tcx> {
+    fn check_fn(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        _: hir_visit::FnKind<'tcx>,
+        _: &'tcx rustc_hir::FnDecl<'tcx>,
+        body: &'tcx Body<'tcx>,
+        _: Span,
+        def_id: rustc_hir::def_id::LocalDefId,
+    ) {
+        let mut state = AssertFnState {
+            cx: self.cx,
+            late_cx: cx,
+            typeck: cx.tcx.typeck(def_id),
+            assertions: [
+                (
+                    AssertionKind::Build,
+                    self.cx
+                        .get_klint_diagnostic_item(crate::symbol::build_assert),
+                    crate::symbol::build_assert,
+                ),
+                (
+                    AssertionKind::Const,
+                    self.cx
+                        .get_klint_diagnostic_item(crate::symbol::const_assert),
+                    crate::symbol::const_assert,
+                ),
+            ],
+            env: LocalEnv::new(),
+        };
+        hir_visit::Visitor::visit_body(&mut state, body);
+    }
+}

--- a/src/diagnostic_items/out_of_band.rs
+++ b/src/diagnostic_items/out_of_band.rs
@@ -1,22 +1,30 @@
 //! Out-of-band attributes attached without source code changes.
 
-use rustc_hir::def::{DefKind, Res};
-use rustc_hir::def_id::{CRATE_DEF_ID, DefId, LOCAL_CRATE};
+use rustc_hir::def::DefKind;
+use rustc_hir::def::Res;
+use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_hir::diagnostic_items::DiagnosticItems;
 use rustc_middle::middle::exported_symbols::ExportedSymbol;
 use rustc_middle::ty::TyCtxt;
+use rustc_span::Symbol;
 
 pub fn infer_missing_items<'tcx>(tcx: TyCtxt<'tcx>, items: &mut DiagnosticItems) {
-    if !items.name_to_id.contains_key(&crate::symbol::build_error) {
-        if let Some(def_id) = infer_build_error_diagnostic_item(tcx) {
-            super::collect_item(tcx, items, crate::symbol::build_error, def_id);
-        }
+    if !items.name_to_id.contains_key(&crate::symbol::build_error)
+        && let Some(def_id) = infer_build_error_diagnostic_item(tcx)
+    {
+        super::collect_item(tcx, items, crate::symbol::build_error, def_id);
     }
 
-    if !items.name_to_id.contains_key(&crate::symbol::c_str) {
-        if let Some(def_id) = infer_c_str_diagnostic_item(tcx) {
-            super::collect_item(tcx, items, crate::symbol::c_str, def_id);
-        }
+    if !items.name_to_id.contains_key(&crate::symbol::build_assert)
+        && let Some(def_id) = infer_build_assert_diagnostic_item(tcx)
+    {
+        super::collect_item(tcx, items, crate::symbol::build_assert, def_id);
+    }
+
+    if !items.name_to_id.contains_key(&crate::symbol::c_str)
+        && let Some(def_id) = infer_c_str_diagnostic_item(tcx)
+    {
+        super::collect_item(tcx, items, crate::symbol::c_str, def_id);
     }
 }
 
@@ -32,6 +40,118 @@ pub fn infer_build_error_diagnostic_item<'tcx>(tcx: TyCtxt<'tcx>) -> Option<DefI
     None
 }
 
+fn infer_local_macro_diagnostic_item<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    expected_path: &[PathSegment],
+) -> Option<DefId> {
+    let (root, rest) = expected_path.split_first()?;
+    let PathSegment::Type(root) = root else {
+        return None;
+    };
+
+    if *root != tcx.crate_name(LOCAL_CRATE) {
+        return None;
+    }
+
+    lookup_with_local_root(tcx, rest)
+}
+
+#[derive(Clone, Copy)]
+enum PathSegment {
+    Type(Symbol),
+    Macro(Symbol),
+}
+
+fn lookup_with_local_root<'tcx>(tcx: TyCtxt<'tcx>, path: &[PathSegment]) -> Option<DefId> {
+    let (segment, rest) = path.split_first()?;
+
+    let mut matches = tcx.hir_crate_items(()).owners().filter_map(|owner| {
+        let def_id = owner.to_def_id();
+        if tcx.opt_parent(def_id) != Some(LOCAL_CRATE.as_def_id()) {
+            return None;
+        }
+
+        match (*segment, tcx.def_kind(def_id)) {
+            (PathSegment::Type(expected), DefKind::Mod) if tcx.item_name(def_id) == expected => {
+                Some(def_id)
+            }
+            (PathSegment::Macro(expected), DefKind::Macro(_))
+                if tcx.item_name(def_id) == expected =>
+            {
+                Some(def_id)
+            }
+            _ => None,
+        }
+    });
+
+    let def_id = matches.next()?;
+
+    if matches.next().is_some() {
+        return None;
+    }
+
+    if rest.is_empty() {
+        Some(def_id)
+    } else {
+        lookup_with_base(tcx, def_id, rest)
+    }
+}
+
+fn lookup_with_base<'tcx>(tcx: TyCtxt<'tcx>, base: DefId, path: &[PathSegment]) -> Option<DefId> {
+    let (segment, rest) = path.split_first()?;
+
+    let children = if let Some(local_def_id) = base.as_local() {
+        tcx.module_children_local(local_def_id)
+    } else {
+        tcx.module_children(base)
+    };
+
+    let mut matches = children.iter().filter_map(|child| {
+        let Res::Def(kind, def_id) = child.res else {
+            return None;
+        };
+
+        match (*segment, kind, child.ident.name) {
+            (PathSegment::Type(expected), DefKind::Mod, actual) if actual == expected => {
+                Some(def_id)
+            }
+            (PathSegment::Macro(expected), DefKind::Macro(_), actual) if actual == expected => {
+                Some(def_id)
+            }
+            _ => None,
+        }
+    });
+
+    let def_id = matches.next()?;
+
+    if matches.next().is_some() {
+        return None;
+    }
+
+    if rest.is_empty() {
+        Some(def_id)
+    } else {
+        lookup_with_base(tcx, def_id, rest)
+    }
+}
+
+pub fn infer_build_assert_diagnostic_item<'tcx>(tcx: TyCtxt<'tcx>) -> Option<DefId> {
+    let name = tcx.crate_name(LOCAL_CRATE);
+
+    if name != crate::symbol::kernel {
+        return None;
+    }
+
+    infer_local_macro_diagnostic_item(
+        tcx,
+        &[
+            PathSegment::Type(crate::symbol::kernel),
+            PathSegment::Type(rustc_span::sym::prelude),
+            PathSegment::Macro(crate::symbol::build_assert),
+        ],
+    )
+}
+
 pub fn infer_c_str_diagnostic_item<'tcx>(tcx: TyCtxt<'tcx>) -> Option<DefId> {
     let name = tcx.crate_name(LOCAL_CRATE);
 
@@ -39,14 +159,11 @@ pub fn infer_c_str_diagnostic_item<'tcx>(tcx: TyCtxt<'tcx>) -> Option<DefId> {
         return None;
     }
 
-    let c_str = tcx
-        .module_children_local(CRATE_DEF_ID)
-        .iter()
-        .find(|c| {
-            c.ident.name == crate::symbol::c_str && matches!(c.res, Res::Def(DefKind::Macro(_), _))
-        })?
-        .res
-        .def_id();
-
-    Some(c_str)
+    infer_local_macro_diagnostic_item(
+        tcx,
+        &[
+            PathSegment::Type(crate::symbol::kernel),
+            PathSegment::Macro(crate::symbol::c_str),
+        ],
+    )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,7 @@ use crate::ctxt::AnalysisCtxt;
 #[macro_use]
 mod ctxt;
 
+mod assert_hierarchy;
 mod atomic_context;
 mod attribute;
 mod binary_analysis;
@@ -110,6 +111,7 @@ impl Callbacks for MyCallbacks {
                 infallible_allocation::INFALLIBLE_ALLOCATION,
                 atomic_context::ATOMIC_CONTEXT,
                 binary_analysis::stack_size::STACK_FRAME_TOO_LARGE,
+                assert_hierarchy::ASSERT_HIERARCHY,
                 hir_lints::c_str_literal::C_STR_LITERAL,
                 hir_lints::not_using_prelude::NOT_USING_PRELUDE,
             ]);
@@ -130,6 +132,12 @@ impl Callbacks for MyCallbacks {
             //     .register_late_pass(|_| Box::new(infallible_allocation::InfallibleAllocation));
             lint_store.register_late_pass(|tcx| {
                 Box::new(atomic_context::AtomicContext {
+                    cx: driver::cx::<MyCallbacks>(tcx),
+                })
+            });
+
+            lint_store.register_late_pass(|tcx| {
+                Box::new(assert_hierarchy::AssertHierarchy {
                     cx: driver::cx::<MyCallbacks>(tcx),
                 })
             });

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -55,6 +55,9 @@ def! {
     // Diagnostic items
     c_str,
     build_error,
+    build_assert,
+    const_assert,
+    static_assert,
 
     CONFIG_FRAME_WARN,
 }

--- a/tests/ui/assert_hierarchy.rs
+++ b/tests/ui/assert_hierarchy.rs
@@ -1,0 +1,151 @@
+#![deny(klint::assert_hierarchy)]
+
+unsafe extern "C" {
+    #[klint::diagnostic_item = "build_error"]
+    safe fn rust_build_error();
+}
+
+#[klint::diagnostic_item = "build_assert"]
+macro_rules! build_assert {
+    ($expr:expr $(,)?) => {
+        if !$expr {
+            rust_build_error();
+        }
+    };
+    ($expr:expr, $msg:expr $(,)?) => {
+        if !$expr {
+            let _ = $msg;
+            rust_build_error();
+        }
+    };
+}
+
+macro_rules! forward_build_assert {
+    ($expr:expr $(,)?) => {
+        build_assert!($expr)
+    };
+}
+
+macro_rules! forward_const_check {
+    ($expr:expr $(,)?) => {
+        build_assert!($expr);
+        let _x = 0usize;
+    };
+}
+
+macro_rules! const_assert {
+    ($expr:expr $(,)?) => {
+        const {
+            assert!($expr);
+        }
+    };
+}
+
+macro_rules! impl_runtime_check {
+    () => {
+        fn macro_generated_runtime(n: usize) {
+            build_assert!(n < LIMIT);
+        }
+    };
+}
+
+const OFFSET: usize = 1;
+const LIMIT: usize = 4;
+
+fn literal_const_only() {
+    build_assert!(1 < LIMIT);
+}
+
+fn const_generic_only<const N: usize>() {
+    build_assert!(OFFSET < N, "offset must stay in bounds");
+}
+
+fn wrapper_const_only() {
+    forward_build_assert!(OFFSET < LIMIT);
+}
+
+// Macro-generated assertions still lint based on the expanded condition.
+fn wrapper_const_generic<const N: usize>() {
+    forward_const_check!(N > 0);
+}
+
+const fn const_helper<const N: usize>() -> usize {
+    N - 1
+}
+
+fn const_fn_helper_only<const N: usize>() {
+    build_assert!(const_helper::<N>() < N);
+}
+
+fn helper<const N: usize>() -> usize {
+    N - 1
+}
+
+fn non_const_fn_helper<const N: usize>() {
+    build_assert!(helper::<N>() < N);
+}
+
+fn const_match_only() {
+    build_assert!(match LIMIT {
+        4 => true,
+        _ => false,
+    });
+}
+
+fn const_comment_comma() {
+    build_assert!(1 /* , */ < LIMIT);
+}
+
+fn const_comment_comma_msg() {
+    build_assert!(1 /* , */ < LIMIT, "still const");
+}
+
+fn local_binding_from_outer_scope() {
+    let offset = OFFSET;
+    build_assert!(offset < LIMIT);
+}
+
+fn local_binding_inside_condition() {
+    build_assert!({
+        let offset = OFFSET;
+        offset < LIMIT
+    });
+}
+
+fn const_assert_static_only() {
+    const_assert!(1 < LIMIT);
+}
+
+fn const_assert_generic<const N: usize>() {
+    const_assert!(OFFSET < N);
+}
+
+#[inline(always)]
+fn runtime_dependent(offset: usize, n: usize) {
+    build_assert!(offset < n);
+}
+
+fn runtime_through_helper(offset: usize) {
+    runtime_dependent(offset, LIMIT);
+}
+
+impl_runtime_check!();
+
+fn main() {
+    literal_const_only();
+    const_generic_only::<LIMIT>();
+    wrapper_const_only();
+    wrapper_const_generic::<LIMIT>();
+    const_fn_helper_only::<LIMIT>();
+    non_const_fn_helper::<LIMIT>();
+    const_match_only();
+    const_comment_comma();
+    const_comment_comma_msg();
+    local_binding_from_outer_scope();
+    local_binding_inside_condition();
+    const_assert_static_only();
+    const_assert_generic::<LIMIT>();
+    runtime_dependent(OFFSET, LIMIT);
+    runtime_through_helper(OFFSET);
+    macro_generated_runtime(OFFSET);
+}

--- a/tests/ui/assert_hierarchy.stderr
+++ b/tests/ui/assert_hierarchy.stderr
@@ -1,0 +1,147 @@
+error: this assertion can use the stronger `static_assert!` form
+  --> $DIR/assert_hierarchy.rs:56:5
+   |
+56 |     build_assert!(1 < LIMIT);
+   |     ------------^^^^^^^^^^^^
+   |     |
+   |     help: replace the macro name: `static_assert`
+   |
+note: this asserted condition is closed over compile-time context, so `static_assert!` is the stronger form here
+  --> $DIR/assert_hierarchy.rs:56:19
+   |
+56 |     build_assert!(1 < LIMIT);
+   |                   ^^^^^^^^^
+note: the lint level is defined here
+  --> $DIR/assert_hierarchy.rs:1:9
+   |
+ 1 | #![deny(klint::assert_hierarchy)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: this assertion can use the stronger `const_assert!` form
+  --> $DIR/assert_hierarchy.rs:60:5
+   |
+60 |     build_assert!(OFFSET < N, "offset must stay in bounds");
+   |     ------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     help: replace the macro name: `const_assert`
+   |
+note: this asserted condition is valid in a generic-aware const context, so `build_assert!` is unnecessary here
+  --> $DIR/assert_hierarchy.rs:60:19
+   |
+60 |     build_assert!(OFFSET < N, "offset must stay in bounds");
+   |                   ^^^^^^^^^^
+
+error: this assertion can use the stronger `static_assert!` form
+  --> $DIR/assert_hierarchy.rs:64:5
+   |
+64 |     forward_build_assert!(OFFSET < LIMIT);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: this asserted condition is closed over compile-time context, so `static_assert!` is the stronger form here
+  --> $DIR/assert_hierarchy.rs:64:27
+   |
+64 |     forward_build_assert!(OFFSET < LIMIT);
+   |                           ^^^^^^^^^^^^^^
+
+error: this assertion can use the stronger `const_assert!` form
+  --> $DIR/assert_hierarchy.rs:69:5
+   |
+69 |     forward_const_check!(N > 0);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: this asserted condition is valid in a generic-aware const context, so `build_assert!` is unnecessary here
+  --> $DIR/assert_hierarchy.rs:69:26
+   |
+69 |     forward_const_check!(N > 0);
+   |                          ^^^^^
+
+error: this assertion can use the stronger `const_assert!` form
+  --> $DIR/assert_hierarchy.rs:77:5
+   |
+77 |     build_assert!(const_helper::<N>() < N);
+   |     ------------^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     help: replace the macro name: `const_assert`
+   |
+note: this asserted condition is valid in a generic-aware const context, so `build_assert!` is unnecessary here
+  --> $DIR/assert_hierarchy.rs:77:19
+   |
+77 |     build_assert!(const_helper::<N>() < N);
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: this assertion can use the stronger `static_assert!` form
+  --> $DIR/assert_hierarchy.rs:89:5
+   |
+89 |       build_assert!(match LIMIT {
+   |       ^-----------
+   |       |
+   |  _____help: replace the macro name: `static_assert`
+   | |
+90 | |         4 => true,
+91 | |         _ => false,
+92 | |     });
+   | |______^
+   |
+note: this asserted condition is closed over compile-time context, so `static_assert!` is the stronger form here
+  --> $DIR/assert_hierarchy.rs:89:19
+   |
+89 |       build_assert!(match LIMIT {
+   |  ___________________^
+90 | |         4 => true,
+91 | |         _ => false,
+92 | |     });
+   | |_____^
+
+error: this assertion can use the stronger `static_assert!` form
+  --> $DIR/assert_hierarchy.rs:96:5
+   |
+96 |     build_assert!(1 /* , */ < LIMIT);
+   |     ------------^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     help: replace the macro name: `static_assert`
+   |
+note: this asserted condition is closed over compile-time context, so `static_assert!` is the stronger form here
+  --> $DIR/assert_hierarchy.rs:96:19
+   |
+96 |     build_assert!(1 /* , */ < LIMIT);
+   |                   ^^^^^^^^^^^^^^^^^
+
+error: this assertion can use the stronger `static_assert!` form
+   --> $DIR/assert_hierarchy.rs:100:5
+    |
+100 |     build_assert!(1 /* , */ < LIMIT, "still const");
+    |     ------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |     |
+    |     help: replace the macro name: `static_assert`
+    |
+note: this asserted condition is closed over compile-time context, so `static_assert!` is the stronger form here
+   --> $DIR/assert_hierarchy.rs:100:19
+    |
+100 |     build_assert!(1 /* , */ < LIMIT, "still const");
+    |                   ^^^^^^^^^^^^^^^^^
+
+error: this assertion can use the stronger `const_assert!` form
+   --> $DIR/assert_hierarchy.rs:109:5
+    |
+109 |       build_assert!({
+    |       ^-----------
+    |       |
+    |  _____help: replace the macro name: `const_assert`
+    | |
+110 | |         let offset = OFFSET;
+111 | |         offset < LIMIT
+112 | |     });
+    | |______^
+    |
+note: this asserted condition is valid in a generic-aware const context, so `build_assert!` is unnecessary here
+   --> $DIR/assert_hierarchy.rs:109:19
+    |
+109 |       build_assert!({
+    |  ___________________^
+110 | |         let offset = OFFSET;
+111 | |         offset < LIMIT
+112 | |     });
+    | |_____^
+
+error: aborting due to 9 previous errors
+

--- a/tests/ui/build_error.rs
+++ b/tests/ui/build_error.rs
@@ -1,3 +1,4 @@
+#![allow(klint::assert_hierarchy)]
 unsafe extern "C" {
     #[klint::diagnostic_item = "build_error"]
     safe fn rust_build_error();

--- a/tests/ui/build_error.stderr
+++ b/tests/ui/build_error.stderr
@@ -1,23 +1,23 @@
  WARN klint::atomic_context Unable to determine property for FFI function `gen_build_error`
  WARN klint::atomic_context Unable to determine property for FFI function `gen_build_error`
 error: this `build_error` reference is not optimized away
-  --> $DIR/build_error.rs:9:13
+  --> $DIR/build_error.rs:10:13
    |
- 9 |             rust_build_error();
+10 |             rust_build_error();
    |             ^^^^^^^^^^^^^^^^^^
 ...
-16 |     build_assert!(false);
+17 |     build_assert!(false);
    |     -------------------- in this macro invocation
    |
 note: which is called from here
-  --> $DIR/build_error.rs:21:5
+  --> $DIR/build_error.rs:22:5
    |
-21 |     inline_call();
+22 |     inline_call();
    |     ^^^^^^^^^^^^^
 note: reference contained in `fn gen_build_error`
-  --> $DIR/build_error.rs:20:1
+  --> $DIR/build_error.rs:21:1
    |
-20 | fn gen_build_error() {
+21 | fn gen_build_error() {
    | ^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `build_assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 


### PR DESCRIPTION
_This PR was split out from #13_

**Add a new `assert_hierarchy` lint that suggests to use stronger build-time assertion forms when possible.**

The lint implements the assertion ordering:

- `static_assert!` > `const_assert!` > `build_assert!`

and warns when a weaker assertion can be replaced with a stronger one.

e.g. cases where
- `build_assert!` can be replaced with `static_assert!`
- `build_assert!` can be replaced with `const_assert!`
- `const_assert!` can be replaced with `static_assert!`


## Implementation Notes

This change adds a dedicated late HIR lint in `src/assert_hierarchy.rs`.

The lint:
- recognizes `build_assert!` and `const_assert!` via diagnostic-item support and macro backtraces
- recovers both the assertion invocation span and the asserted condition span
- classifies conditions into `Build`, `Const` or `Static`

The condition classifier handles:
- literals, `const` items, assoc `const`s, and `const` params
- local expression structure such as blocks, lets, if, match, tuples, arrays, and structs
- `const fn` and `const`-usable method calls
- generic-argument dependence via `typeck` substitutions

This lint does not use any of the mono-graph, interprocedural summary and propagation machinery from the `build_assert_not_inlined` work in #13. It is only local and source-oriented; it inspects the asserted condition itself, along with local expression structure, resolution, `typeck` information, `const`-function legality, and generic dependence.

### Other Changes/Refactors

- Add diagnostic-item support for assert macros in `src/diagnostic_items/out_of_band.rs`.
- ~~Extract out `ClosureDiag` from `infalliable_allocation.rs` to be reused for this lint~~ (reverted in favour of using a derive diagnostic).
- Allow `klint:assert_hierarchy` in `build_error.rs`, so the output isn't polluted by this lint.

### Tests

`tests/ui/assert_hierarchy.rs`
<details><summary>UI test coverage includes:</summary>
<p>

- literals
- `const` generics
- wrapper macros
- macro-generated assertions
- local `const fn` helpers
- comments around macro commas
- outer local bindings
- local bindings inside the asserted condition
- `const_assert!` -> `static_assert!`
</p>
</details> 


### Docs

Add documentation in `doc/assert_hierarchy.md` and the corresponding entry in README "Implemented Lints" section.

-----

<details><summary>Lint output on Linux kernel tree (rust-for-linux/linux@3a2486cc1da5cf637fe5da4540929d67c4540022) </summary>
<p>

```rust

error: this `build_assert!` can be written as `const_assert!` instead
   --> rust/kernel/dma.rs:404:9
    |
404 | /         build_assert!(
405 | |             core::mem::size_of::<T>() > 0,
406 | |             "It doesn't make sense for the allocated type to be a ZST"
407 | |         );
    | |_________^
    |
note: this asserted condition is valid in a generic-aware const context, so `build_assert!` is unnecessary here
   --> rust/kernel/dma.rs:405:13
    |
405 |             core::mem::size_of::<T>() > 0,
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: `-D klint::assert-hierarchy` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(klint::assert_hierarchy)]`

error: this `build_assert!` can be written as `const_assert!` instead
   --> rust/kernel/i2c.rs:113:9
    |
113 | /         build_assert!(
114 | |             T::ACPI_ID_TABLE.is_some() || T::OF_ID_TABLE.is_some() || T::I2C_ID_TABLE.is_some(),
115 | |             "At least one of ACPI/OF/Legacy tables must be present when registering an i2c driver"
116 | |         );
    | |_________^
    |
note: this asserted condition is valid in a generic-aware const context, so `build_assert!` is unnecessary here
   --> rust/kernel/i2c.rs:114:13
    |
114 |             T::ACPI_ID_TABLE.is_some() || T::OF_ID_TABLE.is_some() || T::I2C_ID_TABLE.is_some(),
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: this `build_assert!` can be written as `const_assert!` instead
   --> rust/kernel/list/arc.rs:255:9
    |
255 |         build_assert!(ID != ID2);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
    |
note: this asserted condition is valid in a generic-aware const context, so `build_assert!` is unnecessary here
   --> rust/kernel/list/arc.rs:255:23
    |
255 |         build_assert!(ID != ID2);
    |                       ^^^^^^^^^

error: this `build_assert!` can be written as `const_assert!` instead
   --> rust/kernel/sync/locked_by.rs:103:9
    |
103 | /         build_assert!(
104 | |             size_of::<Lock<U, B>>() > 0,
105 | |             "The lock type cannot be a ZST because it may be impossible to distinguish instances"
106 | |         );
    | |_________^
    |
note: this asserted condition is valid in a generic-aware const context, so `build_assert!` is unnecessary here
   --> rust/kernel/sync/locked_by.rs:104:13
    |
104 |             size_of::<Lock<U, B>>() > 0,
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: this `build_assert!` can be written as `const_assert!` instead
   --> rust/kernel/sync/locked_by.rs:129:9
    |
129 | /         build_assert!(
130 | |             size_of::<U>() > 0,
131 | |             "`U` cannot be a ZST because `owner` wouldn't be unique"
132 | |         );
    | |_________^
    |
note: this asserted condition is valid in a generic-aware const context, so `build_assert!` is unnecessary here
   --> rust/kernel/sync/locked_by.rs:130:13
    |
130 |             size_of::<U>() > 0,
    |             ^^^^^^^^^^^^^^^^^^

error: this `build_assert!` can be written as `const_assert!` instead
   --> rust/kernel/sync/locked_by.rs:158:9
    |
158 | /         build_assert!(
159 | |             size_of::<U>() > 0,
160 | |             "`U` cannot be a ZST because `owner` wouldn't be unique"
161 | |         );
    | |_________^
    |
note: this asserted condition is valid in a generic-aware const context, so `build_assert!` is unnecessary here
   --> rust/kernel/sync/locked_by.rs:159:13
    |
159 |             size_of::<U>() > 0,
    |             ^^^^^^^^^^^^^^^^^^

error: this `build_assert!` can be written as `const_assert!` instead
   --> rust/kernel/xarray.rs:234:9
    |
234 | /         build_assert!(
235 | |             T::FOREIGN_ALIGN >= 4,
236 | |             "pointers stored in XArray must be 4-byte aligned"
237 | |         );
    | |_________^
    |
note: this asserted condition is valid in a generic-aware const context, so `build_assert!` is unnecessary here
   --> rust/kernel/xarray.rs:235:13
    |
235 |             T::FOREIGN_ALIGN >= 4,
    |             ^^^^^^^^^^^^^^^^^^^^^

error: aborting due to 7 previous errors
```

(same cases as #13 btw)
</p>
</details> 