### PR TITLE
Fix unwrap panic by flatten the Options

### DIFF
--- a/src/ctxt.rs
+++ b/src/ctxt.rs
@@ -224,7 +224,8 @@ impl<'tcx> AnalysisCtxt<'tcx> {
                 |row| row.get(0),
             )
             .optional()
-            .unwrap()?;
+            .ok()
+            .flatten()?;
         let mut decode_ctx = crate::serde::DecodeContext::new(self.tcx, &value_encoded, span);
         let value = Q::decode_value(&mut decode_ctx);
         Some(value)


### PR DESCRIPTION
I got a panic of unwrap when using klint to check Asterinas

```
thread 'rustc' (243883) panicked at src/ctxt.rs:227:14:
called `Result::unwrap()` on an `Err` value: 
SqliteFailure(Error { code: Unknown, extended_code: 1 }, Some("no such table: klint_diagnostic_items"))
```

So the PR fixes it by flattening and forwarding the None value.