### PR TITLE
Explicit rust-toolchain version: nightly => nightly-2026-03-19

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -3,5 +3,5 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
 [toolchain]
-channel = "nightly"
+channel = "nightly-2026-03-19"
 components = ["llvm-tools-preview", "rustc-dev", "rust-src"]


### PR DESCRIPTION
Nightly toolchain is too vague, and often results in compilation errors due to rustc internal API changes.

This PR makes the version explicit, and avoids the frustrating compilation failure by user's incompatible nightly version (and also avoid tricks to override the toolchain).