### PR TITLE
build: Disable lld only for x86_64-unknown-linux-gnu

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,5 +5,5 @@
 [env]
 RUSTC_BOOTSTRAP = "1"
 
-[build]
+[target.x86_64-unknown-linux-gnu]
 rustflags = ["-Clinker-features=-lld"]


### PR DESCRIPTION
Builds on aarch64 fail with
```
error: `-C linker-features=-lld` is unstable on the `aarch64-unknown-linux-gnu` target. The `-Z unstable-options` flag must also be passed to use it on this target
```
otherwise. Since lld is only the default linker on x86_64-unknown-linux-gnu disable it only for that target.